### PR TITLE
fix: mobile portfolio and wiki search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 build:
 	uv run build.py
-	uv run python -m pagefind --site public/wiki-pages --output-path public/pagefind
+	uv run python -m pagefind --site public --output-path public/pagefind --exclude-selectors "body:not(.wiki-page)"
 
 serve:
 	uv run python -m http.server 8000 --directory public

--- a/src/static/css/index.css
+++ b/src/static/css/index.css
@@ -9,9 +9,9 @@
 	div.about-picture { 
 		width: 100%;
 	}
-    body {
-        width: 75%;
-    }
+  body {
+    width: 75%;
+  }
 	.main {
 		font-size: 1rem;
 	}
@@ -24,26 +24,23 @@
 	.portfolio-description {
 		width: 100%;
 	}
-    .project-view-button {
-        font-size: 1rem;
-        width: 50%;
-    }
+  .project-view-button {
+    font-size: 1rem;
+    width: 50%;
+  }
 	details[open] summary span.icon {
 		font-size: 1rem;
-	}
-	#resume-pdf-viewer {
-		height: 100%;
 	}
 	#social-media-photo {
 		width: 25px;
 	}
-    .blog-logo-image {
-        width: 100%;
-    }
-    .blog-post-content {
-        font-size: 1.25rem;
-        width: 85%;
-    }
+  .blog-logo-image {
+    width: 100%;
+  }
+  .blog-post-content {
+    font-size: 1.25rem;
+    width: 85%;
+  }
 }
 
 

--- a/src/static/css/portfolio.css
+++ b/src/static/css/portfolio.css
@@ -18,10 +18,6 @@
 	display: list-item;
 }
 
-#header.portfolio-header {
-	display: inline-block;
-}
-
 .portfolio-description {
 	width: 75%;
 	display: flex;

--- a/src/static/portfolio.html
+++ b/src/static/portfolio.html
@@ -110,7 +110,7 @@
       </details>
       <details id="collapsible-sections">
         <summary id="selected-writing" class="portfolio-header">
-          <h3 id="header" class="portfolio-header">Selected Presentations & Writing</h3>
+          <h3 id="header" class="portfolio-header">Presentations & Writing</h3>
         </summary>
         <article id="balto-city-salaries" class="portfolio-description">
           <a

--- a/src/templates/wiki-template.html
+++ b/src/templates/wiki-template.html
@@ -14,10 +14,13 @@
     <script type="text/javascript" src="/js/footer.js"></script>
   </head>
 
-  <body class="grid-wrapper">
+  <body class="grid-wrapper wiki-page">
     <custom-header></custom-header>
-    <main id="wiki-post-main" class="main">
-      <h3><a href="/wiki-pages/index.html">home garden</a> / {title}</h3>
+    <main id="wiki-post-main" class="main" data-pagefind-body>
+      <h3 data-pagefind-ignore>
+        <a href="/wiki-pages/index.html">home garden</a> / 
+        <span data-pagefind-meta="title">{title}</span>
+      </h3>
       {content}
     </main>
     <br />


### PR DESCRIPTION
- shortens portfolio section to appear on single line on mobile
- correctly targets baseURL and excludes non wiki pages when generating wiki search using PageFind