### PR TITLE
fix: remove duplicate summary markers on portfolio page

### DIFF
--- a/src/static/css/portfolio.css
+++ b/src/static/css/portfolio.css
@@ -15,6 +15,7 @@
 }
 
 .portfolio-header {
+  display: list-item;
 }
 
 .portfolio-description {

--- a/src/static/css/portfolio.css
+++ b/src/static/css/portfolio.css
@@ -15,7 +15,6 @@
 }
 
 .portfolio-header {
-	display: list-item;
 }
 
 .portfolio-description {

--- a/src/static/portfolio.html
+++ b/src/static/portfolio.html
@@ -20,7 +20,7 @@
 
     <main id="portfolio-main" , class="main">
       <details id="collapsible-sections">
-        <summary id="programming-projects" class="portfolio-header">
+        <summary id="programming-projects">
           <h3 id="header" class="portfolio-header">Code!</h3>
         </summary>
         <article id="balto-city-salaries" class="portfolio-description">
@@ -109,7 +109,7 @@
         </article>
       </details>
       <details id="collapsible-sections">
-        <summary id="selected-writing" class="portfolio-header">
+        <summary id="selected-writing">
           <h3 id="header" class="portfolio-header">Presentations & Writing</h3>
         </summary>
         <article id="balto-city-salaries" class="portfolio-description">


### PR DESCRIPTION
- deletes `portfolio-header` class from parent tag to `summary`